### PR TITLE
Updated Hugo + Small Fixes

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
 
 DIR=$(mktemp -d)
+HUGO_VERSION=0.17
+
 cd $DIR
 
 # Install awscli python lib + deps in buildroot
 pip install awscli -t .
+
 # Fetch aws cli wrapper from github
-wget https://raw.githubusercontent.com/aws/aws-cli/1.9.15/bin/aws \
+wget https://raw.githubusercontent.com/aws/aws-cli/develop/bin/aws \
 	-O awscli.py
+
 # Fetch hugo release (statically compile go binary)
-wget https://github.com/spf13/hugo/releases/download/v0.15/hugo_0.15_linux_amd64.tar.gz
-tar -xf hugo_0.15_linux_amd64.tar.gz
-rm -f hugo_0.15_linux_amd64.tar.gz
-mv hugo_0.15_linux_amd64/hugo_0.15_linux_amd64 hugo_0.15_linux_amd64.go
-rm -rf hugo_0.15_linux_amd64
+wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+tar -xf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+rm -f hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+mv hugo_${HUGO_VERSION}_linux_amd64/hugo_${HUGO_VERSION}_linux_amd64 hugo.go
+rm -rf hugo_${HUGO_VERSION}_linux_amd64
+
 # cleanup
 find . -name "*.pyc" -delete
+
 # Fetch the main script from this repo
-wget https://raw.githubusercontent.com/jolexa/hugo-lambda-function/master/main.py
+wget https://raw.githubusercontent.com/abdel/hugo-lambda-function/master/main.py
+
 # create zip
 zip -r9 /tmp/hugo-lambda-function.zip *
 cd ..
+
 # cleanup
 rm -rf $DIR

--- a/build-package.sh
+++ b/build-package.sh
@@ -9,7 +9,7 @@ cd $DIR
 pip install pyyaml awscli -t .
 
 # Fetch aws cli wrapper from github
-wget https://raw.githubusercontent.com/aws/aws-cli/develop/bin/aws \
+wget https://raw.githubusercontent.com/aws/aws-cli/1.11.21/bin/aws \
 	-O awscli.py
 
 # Fetch hugo release (statically compile go binary)
@@ -23,7 +23,7 @@ rm -rf hugo_${HUGO_VERSION}_linux_amd64
 find . -name "*.pyc" -delete
 
 # Fetch the main script from this repo
-wget https://raw.githubusercontent.com/abdel/hugo-lambda-function/master/main.py
+wget https://raw.githubusercontent.com/jolexa/hugo-lambda-function/master/main.py
 
 # create zip
 zip -r9 /tmp/hugo-lambda-function.zip *

--- a/build-package.sh
+++ b/build-package.sh
@@ -6,7 +6,7 @@ HUGO_VERSION=0.17
 cd $DIR
 
 # Install awscli python lib + deps in buildroot
-pip install awscli -t .
+pip install pyyaml awscli -t .
 
 # Fetch aws cli wrapper from github
 wget https://raw.githubusercontent.com/aws/aws-cli/develop/bin/aws \

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def lambda_handler(event, context):
     zfile.extractall("/tmp/unzipped")
     builddir = "/tmp/unzipped/" + reponame + "-master/"
 
-    subprocess.call("/var/task/hugo_0.15_linux_amd64.go" , shell=True, cwd=builddir)
+    subprocess.call("/var/task/hugo.go" , shell=True, cwd=builddir)
     pushdir = builddir + "public/"
     bucketuri = "s3://" + reponame + "/"
     subprocess.call("python /var/task/awscli.py s3 sync --size-only --delete --sse AES256 " + pushdir + " " + bucketuri, shell=True)


### PR DESCRIPTION
* Updated Hugo to v0.17
* Added a `HUGO_VERSION` variable to easily update versions in the future
* Lambda function threw errors for missing `yaml` module, added `pyyaml` to `pip install`
* Changed go filename to `hugo.go` to avoid updating it for versions as well